### PR TITLE
Convert keys even if gajim account doesn't exist

### DIFF
--- a/pidgin2gajim.py
+++ b/pidgin2gajim.py
@@ -122,7 +122,10 @@ if __name__ == "__main__":
                 fp.append('')
             fp[1] = fp[1].split('/')[0]
             fp[2] = 'xmpp'
-            gajim_fps[fp[1]] += '\t'.join(fp) + '\n'
+            try:
+                gajim_fps[fp[1]] += '\t'.join(fp) + '\n'
+            except:
+                continue
 
     for account in keys:
         serialized_private_key = keys[account]['dsakey'].serializePrivateKey()


### PR DESCRIPTION
This makes it easier to use the script because you can convert/create
all keys from pidgin accounts once and decide when to copy them to each
gajim account, without having to use the same account names in pidgin
and gajim